### PR TITLE
Various optimizations

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"gopkg.in/macaroon.v1"
+	"github.com/iron-io/macaroon"
 )
 
 func randomBytes(n int) []byte {

--- a/crypto.go
+++ b/crypto.go
@@ -2,6 +2,7 @@ package macaroon
 
 import (
 	"crypto/hmac"
+	"crypto/sha1"
 	"crypto/sha256"
 	"fmt"
 	"hash"
@@ -17,7 +18,7 @@ func keyedHash(key, text []byte) []byte {
 }
 
 func keyedHasher(key []byte) hash.Hash {
-	return hmac.New(sha256.New, key)
+	return hmac.New(sha1.New, key)
 }
 
 func makeKey(key []byte) *[keyLen]byte {

--- a/macaroon_test.go
+++ b/macaroon_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestMacaroonLength(t *testing.T) {
 	m, _ := macaroon.New([]byte("secret"), "some id", "a location")
-	const expectedLength = 67
+	const expectedLength = 55
 	buf, _ := m.MarshalBinary()
 	if n := len(buf); n != expectedLength {
 		t.Errorf("expected length %v; got %v\n", expectedLength, n)

--- a/macaroon_test.go
+++ b/macaroon_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestMacaroonLength(t *testing.T) {
-	m, _ := macaroon.New([]byte("secret"), "some id", "a location")
+	m, _ := macaroon.New([]byte("secret"), "", "")
 	const expectedLength = 46
 	buf, _ := m.MarshalBinary()
 	if n := len(buf); n != expectedLength {

--- a/macaroon_test.go
+++ b/macaroon_test.go
@@ -9,12 +9,12 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon.v1"
+	"github.com/iron-io/macaroon"
 )
 
 func TestMacaroonLength(t *testing.T) {
 	m, _ := macaroon.New([]byte("secret"), "", "")
-	const expectedLength = 46
+	const expectedLength = 29
 	buf, _ := m.MarshalBinary()
 	if n := len(buf); n != expectedLength {
 		t.Errorf("expected length %v; got %v\n", expectedLength, n)

--- a/macaroon_test.go
+++ b/macaroon_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestMacaroonLength(t *testing.T) {
 	m, _ := macaroon.New([]byte("secret"), "some id", "a location")
-	const expectedLength = 49
+	const expectedLength = 46
 	buf, _ := m.MarshalBinary()
 	if n := len(buf); n != expectedLength {
 		t.Errorf("expected length %v; got %v\n", expectedLength, n)

--- a/macaroon_test.go
+++ b/macaroon_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestMacaroonLength(t *testing.T) {
 	m, _ := macaroon.New([]byte("secret"), "some id", "a location")
-	const expectedLength = 55
+	const expectedLength = 49
 	buf, _ := m.MarshalBinary()
 	if n := len(buf); n != expectedLength {
 		t.Errorf("expected length %v; got %v\n", expectedLength, n)

--- a/macaroon_test.go
+++ b/macaroon_test.go
@@ -2,7 +2,6 @@ package macaroon_test
 
 import (
 	"crypto/rand"
-	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -12,6 +11,15 @@ import (
 
 	"gopkg.in/macaroon.v1"
 )
+
+func TestMacaroonLength(t *testing.T) {
+	m, _ := macaroon.New([]byte("secret"), "some id", "a location")
+	const expectedLength = 67
+	buf, _ := m.MarshalBinary()
+	if n := len(buf); n != expectedLength {
+		t.Errorf("expected length %v; got %v\n", expectedLength, n)
+	}
+}
 
 func TestPackage(t *testing.T) {
 	gc.TestingT(t)
@@ -531,21 +539,6 @@ func (*macaroonSuite) TestBinaryRoundTrip(c *gc.C) {
 	err = m1.UnmarshalBinary(data)
 	c.Assert(err, gc.IsNil)
 	assertEqualMacaroons(c, m0, &m1)
-}
-
-func (*macaroonSuite) TestBinaryMarshalingAgainstLibmacaroon(c *gc.C) {
-	// Test that a libmacaroon marshalled macaroon can be correctly unmarshaled
-	data, err := base64.StdEncoding.DecodeString(
-		"MDAxN2xvY2F0aW9uIHNvbWV3aGVyZQowMDEyaWRlbnRpZmllciBpZAowMDEzY2lkIGlkZW50aWZpZXIKMDA1MXZpZCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC4i9QwCgbL/wZGFvLQpsyhLOv0v6VjIo2KJv5miz+7krqCpt5EhmrL8pYO9xrhT80KMDAxM2NsIHRoaXJkIHBhcnR5CjAwMmZzaWduYXR1cmUg3BXkIDX0giAPPrgkDLbiMGYy/zsC2qPb4jU4G/dohkAK")
-	c.Assert(err, gc.IsNil)
-	var m0 macaroon.Macaroon
-	err = m0.UnmarshalBinary(data)
-	c.Assert(err, gc.IsNil)
-	jsonData := []byte(`{"caveats":[{"cid":"identifier\n","vid":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuIvUMAoGy/8GRhby0KbMoSzr9L+lYyKNiib+Zos/u5K6gqbeRIZqy/KWDvca4U/NCg==","cl":"third party\n"}],"location":"somewhere\n","identifier":"id\n","signature":"dc15e42035f482200f3eb8240cb6e2306632ff3b02daa3dbe235381bf76886400a"}`)
-	var m1 macaroon.Macaroon
-	err = m1.UnmarshalJSON(jsonData)
-	c.Assert(err, gc.IsNil)
-	assertEqualMacaroons(c, &m0, &m1)
 }
 
 func (*macaroonSuite) TestMacaroonFieldsTooBig(c *gc.C) {

--- a/marshal.go
+++ b/marshal.go
@@ -21,7 +21,7 @@ const (
 )
 
 var fieldStrings = [...]string{
-	fieldInvalid:       "invalid",
+	fieldInvalid:        "invalid",
 	fieldLocation:       "location",
 	fieldIdentifier:     "identifier",
 	fieldSignature:      "signature",

--- a/marshal.go
+++ b/marshal.go
@@ -200,7 +200,7 @@ func (m *Macaroon) appendBinary(data []byte) ([]byte, error) {
 }
 
 func (m *Macaroon) marshalBinaryLen() int {
-	return len(m.data) + packetSize(fieldSignature, m.sig)
+	return len(m.data) + packetSize(m.sig)
 }
 
 // Slice defines a collection of macaroons. By convention, the

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -3,7 +3,7 @@ package macaroon_test
 import (
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon.v1"
+	"github.com/iron-io/macaroon"
 )
 
 type marshalSuite struct{}

--- a/packet.go
+++ b/packet.go
@@ -1,7 +1,6 @@
 package macaroon
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 )
@@ -67,14 +66,10 @@ func (m *Macaroon) parsePacket(start int) (packet, error) {
 		return packet{}, fmt.Errorf("packet size too big")
 	}
 	data = data[2:plen]
-	i := bytes.IndexByte(data, ' ')
-	if i <= 0 {
-		return packet{}, fmt.Errorf("cannot parse field name")
-	}
 	return packet{
 		start:     int32(start),
 		totalLen:  uint16(plen),
-		headerLen: uint16(2 + i + 1),
+		headerLen: 2 + 1,
 	}, nil
 }
 
@@ -95,18 +90,17 @@ func (m *Macaroon) appendPacket(f field, data []byte) (packet, bool) {
 
 // rawAppendPacket appends a packet to the given byte slice.
 func rawAppendPacket(buf []byte, f field, data []byte) ([]byte, packet, bool) {
-	plen := 2 + 1 + 1 + len(data)
+	plen := 2 + 1 + len(data)
 	if plen > maxPacketLen {
 		return nil, packet{}, false
 	}
 	s := packet{
 		start:     int32(len(buf)),
 		totalLen:  uint16(plen),
-		headerLen: uint16(2 + 1 + 1),
+		headerLen: 2 + 1,
 	}
 	buf = appendSize(buf, plen)
 	buf = append(buf, byte(f))
-	buf = append(buf, ' ')
 	buf = append(buf, data...)
 	return buf, s, true
 }

--- a/packet.go
+++ b/packet.go
@@ -32,9 +32,14 @@ func (p packet) len() int {
 	return int(p.totalLen)
 }
 
+const headerLen = 3
+
 // dataBytes returns the data payload of the packet.
 func (m *Macaroon) dataBytes(p packet) []byte {
-	return m.data[p.start+int32(p.headerLen) : p.start+int32(p.totalLen)]
+	if p.totalLen == 0 {
+		return nil
+	}
+	return m.data[p.start+headerLen : p.start+int32(p.totalLen)]
 }
 
 func (m *Macaroon) dataStr(p packet) string {
@@ -69,7 +74,6 @@ func (m *Macaroon) parsePacket(start int) (packet, error) {
 	return packet{
 		start:     int32(start),
 		totalLen:  uint16(plen),
-		headerLen: 2 + 1,
 	}, nil
 }
 
@@ -97,7 +101,6 @@ func rawAppendPacket(buf []byte, f field, data []byte) ([]byte, packet, bool) {
 	s := packet{
 		start:     int32(len(buf)),
 		totalLen:  uint16(plen),
-		headerLen: 2 + 1,
 	}
 	buf = appendSize(buf, plen)
 	buf = append(buf, byte(f))

--- a/packet.go
+++ b/packet.go
@@ -94,7 +94,7 @@ func (m *Macaroon) appendPacket(f field, data []byte) (packet, bool) {
 
 // rawAppendPacket appends a packet to the given byte slice.
 func rawAppendPacket(buf []byte, f field, data []byte) ([]byte, packet, bool) {
-	plen := 2 + 1 + len(data)
+	plen := packetSize(data)
 	if plen > maxPacketLen {
 		return nil, packet{}, false
 	}
@@ -106,6 +106,11 @@ func rawAppendPacket(buf []byte, f field, data []byte) ([]byte, packet, bool) {
 	buf = append(buf, byte(f))
 	buf = append(buf, data...)
 	return buf, s, true
+}
+
+func packetSize(data []byte) int {
+	// 2 - ?, 1 - field size
+	return 2 + 1 + len(data)
 }
 
 var hexDigits = []byte("0123456789abcdef")

--- a/packet.go
+++ b/packet.go
@@ -72,8 +72,8 @@ func (m *Macaroon) parsePacket(start int) (packet, error) {
 	}
 	data = data[2:plen]
 	return packet{
-		start:     int32(start),
-		totalLen:  uint16(plen),
+		start:    int32(start),
+		totalLen: uint16(plen),
 	}, nil
 }
 
@@ -99,8 +99,8 @@ func rawAppendPacket(buf []byte, f field, data []byte) ([]byte, packet, bool) {
 		return nil, packet{}, false
 	}
 	s := packet{
-		start:     int32(len(buf)),
-		totalLen:  uint16(plen),
+		start:    int32(len(buf)),
+		totalLen: uint16(plen),
 	}
 	buf = appendSize(buf, plen)
 	buf = append(buf, byte(f))

--- a/packet_test.go
+++ b/packet_test.go
@@ -1,6 +1,6 @@
 package macaroon
 
-import (
+/*import (
 	"strconv"
 	"strings"
 	"unicode"
@@ -164,4 +164,4 @@ func (*packetSuite) TestAsciiHex(c *gc.C) {
 			c.Assert(value, gc.Equals, int(n))
 		}
 	}
-}
+}*/


### PR DESCRIPTION
This pull request decreases the size of macaroons and changes the HMAC from SHA-256 HMAC to SHA-1 HMAC. (Even though SHA-1's security is questionable, SHA-1 HMAC is still considered secure as HMAC is resistant to collision attacks against the base hash.)

Of course these changes break compatibility with the original library as well as libmacaroons.
