### PR TITLE
caveats optimization and stuff

### DIFF
--- a/macaroon.go
+++ b/macaroon.go
@@ -10,10 +10,8 @@ package macaroon
 import (
 	"bytes"
 	"crypto/hmac"
-	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
-	"io"
 )
 
 // Macaroon holds a macaroon.
@@ -28,26 +26,8 @@ type Macaroon struct {
 
 	location packet
 	id       packet
-	caveats  []caveat
+	caveats  packet
 	sig      []byte
-}
-
-// caveat holds a first person or third party caveat.
-type caveat struct {
-	location       packet
-	caveatId       packet
-	verificationId packet
-}
-
-type Caveat struct {
-	Id       string
-	Location string
-}
-
-// isThirdParty reports whether the caveat must be satisfied
-// by some third party (if not, it's a first person caveat).
-func (cav *caveat) isThirdParty() bool {
-	return cav.verificationId.len() > 0
 }
 
 // New returns a new macaroon with the given root key,
@@ -80,7 +60,6 @@ func (m *Macaroon) Clone() *Macaroon {
 	// Ensure that if any data is appended to the new
 	// macaroon, it will copy data and caveats.
 	m1.data = m1.data[0:len(m1.data):len(m1.data)]
-	m1.caveats = m1.caveats[0:len(m1.caveats):len(m1.caveats)]
 	m1.sig = append([]byte(nil), m.sig...)
 	return &m1
 }
@@ -97,6 +76,10 @@ func (m *Macaroon) Id() string {
 	return m.dataStr(m.id)
 }
 
+func (m *Macaroon) caveatsRaw() []byte {
+	return m.dataBytes(m.caveats)
+}
+
 // Signature returns the macaroon's signature.
 func (m *Macaroon) Signature() []byte {
 	return append([]byte(nil), m.sig...)
@@ -104,53 +87,28 @@ func (m *Macaroon) Signature() []byte {
 
 // Caveats returns the macaroon's caveats.
 // This method will probably change, and it's important not to change the returned caveat.
-func (m *Macaroon) Caveats() []Caveat {
-	caveats := make([]Caveat, len(m.caveats))
-	for i, cav := range m.caveats {
-		caveats[i] = Caveat{
-			Id:       m.dataStr(cav.caveatId),
-			Location: m.dataStr(cav.location),
-		}
-	}
-	return caveats
+func (m *Macaroon) GetCaveats(v interface{}) error {
+	err := UnMarshalCaveats(v, m.caveatsRaw())
+
+	return err
 }
 
-// appendCaveat appends a caveat without modifying the macaroon's signature.
-func (m *Macaroon) appendCaveat(caveatId string, verificationId []byte, loc string) (*caveat, error) {
-	var cav caveat
+func (m *Macaroon) SetCaveats(v interface{}) error {
+	cavData, err := MarshalCaveats(v)
+
 	var ok bool
-	if caveatId != "" {
-		cav.caveatId, ok = m.appendPacket(fieldCaveatId, []byte(caveatId))
-		if !ok {
-			return nil, fmt.Errorf("caveat identifier too big")
+	if err == nil {
+		m.caveats, ok = m.appendPacket(fieldCaveat, cavData)
+		if ok {
+			sig := keyedHasher(m.sig)
+			sig.Write(cavData)
+			m.sig = sig.Sum(m.sig[:0])
+			return nil
+		} else {
+			return fmt.Errorf("caveat identifier too big")
 		}
 	}
-	if len(verificationId) > 0 {
-		cav.verificationId, ok = m.appendPacket(fieldVerificationId, verificationId)
-		if !ok {
-			return nil, fmt.Errorf("caveat verification id too big")
-		}
-	}
-	if loc != "" {
-		cav.location, ok = m.appendPacket(fieldCaveatLocation, []byte(loc))
-		if !ok {
-			return nil, fmt.Errorf("caveat location too big")
-		}
-	}
-	m.caveats = append(m.caveats, cav)
-	return &m.caveats[len(m.caveats)-1], nil
-}
-
-func (m *Macaroon) addCaveat(caveatId string, verificationId []byte, loc string) error {
-	cav, err := m.appendCaveat(caveatId, verificationId, loc)
-	if err != nil {
-		return err
-	}
-	sig := keyedHasher(m.sig)
-	sig.Write(m.dataBytes(cav.verificationId))
-	sig.Write(m.dataBytes(cav.caveatId))
-	m.sig = sig.Sum(m.sig[:0])
-	return nil
+	return err
 }
 
 // Bind prepares the macaroon for being used to discharge the
@@ -158,30 +116,6 @@ func (m *Macaroon) addCaveat(caveatId string, verificationId []byte, loc string)
 // used before it is used in the discharges argument to Verify.
 func (m *Macaroon) Bind(sig []byte) {
 	m.sig = bindForRequest(sig, m.sig)
-}
-
-// AddFirstPartyCaveat adds a caveat that will be verified
-// by the target service.
-func (m *Macaroon) AddFirstPartyCaveat(caveatId string) error {
-	return m.addCaveat(caveatId, nil, "")
-}
-
-// AddThirdPartyCaveat adds a third-party caveat to the macaroon,
-// using the given shared root key, caveat id and location hint.
-// The caveat id should encode the root key in some
-// way, either by encrypting it with a key known to the third party
-// or by holding a reference to it stored in the third party's
-// storage.
-func (m *Macaroon) AddThirdPartyCaveat(rootKey []byte, caveatId string, loc string) error {
-	return m.addThirdPartyCaveatWithRand(rootKey, caveatId, loc, rand.Reader)
-}
-
-func (m *Macaroon) addThirdPartyCaveatWithRand(rootKey []byte, caveatId string, loc string, r io.Reader) error {
-	verificationId, err := encrypt(m.sig, rootKey, r)
-	if err != nil {
-		return err
-	}
-	return m.addCaveat(caveatId, verificationId, loc)
 }
 
 // bndForRequest binds the given macaroon
@@ -198,82 +132,25 @@ func bindForRequest(rootSig, dischargeSig []byte) []byte {
 
 // Verify verifies that the receiving macaroon is valid.
 // The root key must be the same that the macaroon was originally
-// minted with. The check function is called to verify each
-// first-party caveat - it should return an error if the
-// condition is not met.
-//
-// The discharge macaroons should be provided in discharges.
-//
+// minted with.
 // Verify returns nil if the verification succeeds.
-func (m *Macaroon) Verify(rootKey []byte, check func(caveat string) error, discharges []*Macaroon) error {
-	// TODO(rog) consider distinguishing between classes of
-	// check error - some errors may be resolved by minting
-	// a new macaroon; others may not.
-	used := make([]int, len(discharges))
-	if err := m.verify(m.sig, rootKey, check, discharges, used); err != nil {
+func (m *Macaroon) Verify(rootKey []byte) error {
+	if err := m.verify(m.sig, rootKey); err != nil {
 		return err
-	}
-	for i, dm := range discharges {
-		switch used[i] {
-		case 0:
-			return fmt.Errorf("discharge macaroon %q was not used", dm.Id())
-		case 1:
-			continue
-		default:
-			// Should be impossible because of check in verify, but be defensive.
-			return fmt.Errorf("discharge macaroon %q was used more than once", dm.Id())
-		}
 	}
 	return nil
 }
 
-func (m *Macaroon) verify(rootSig []byte, rootKey []byte, check func(caveat string) error, discharges []*Macaroon, used []int) error {
+func (m *Macaroon) verify(rootSig []byte, rootKey []byte) error {
 	if len(rootSig) == 0 {
 		rootSig = m.sig
 	}
 	caveatSig := keyedHash(rootKey, m.dataBytes(m.id))
-	for i, cav := range m.caveats {
-		if cav.isThirdParty() {
-			cavKey, err := decrypt(caveatSig, m.dataBytes(cav.verificationId))
-			if err != nil {
-				return fmt.Errorf("failed to decrypt caveat %d signature: %v", i, err)
-			}
-			// We choose an arbitrary error from one of the
-			// possible discharge macaroon verifications
-			// if there's more than one discharge macaroon
-			// with the required id.
-			found := false
-			for di, dm := range discharges {
-				if !bytes.Equal(dm.dataBytes(dm.id), m.dataBytes(cav.caveatId)) {
-					continue
-				}
-				found = true
 
-				// It's important that we do this before calling verify,
-				// as it prevents potentially infinite recursion.
-				if used[di]++; used[di] > 1 {
-					return fmt.Errorf("discharge macaroon %q was used more than once", dm.Id())
-				}
-				if err := dm.verify(rootSig, cavKey, check, discharges, used); err != nil {
-					return err
-				}
-				break
-			}
-			if !found {
-				return fmt.Errorf("cannot find discharge macaroon for caveat %q", m.dataBytes(cav.caveatId))
-			}
-		} else {
-			if err := check(string(m.dataBytes(cav.caveatId))); err != nil {
-				return err
-			}
-		}
-		sig := keyedHasher(caveatSig)
-		sig.Write(m.dataBytes(cav.verificationId))
-		sig.Write(m.dataBytes(cav.caveatId))
-		caveatSig = sig.Sum(caveatSig[:0])
-	}
-	// TODO perhaps we should actually do this check before doing
-	// all the potentially expensive caveat checks.
+	sig := keyedHasher(caveatSig)
+	sig.Write(m.dataBytes(m.caveats))
+	caveatSig = sig.Sum(caveatSig[:0])
+
 	boundSig := bindForRequest(rootSig, caveatSig)
 	if !hmac.Equal(boundSig, m.sig) {
 		return fmt.Errorf("signature mismatch after caveat verification")

--- a/marshal.go
+++ b/marshal.go
@@ -1,10 +1,13 @@
 package macaroon
 
 import (
-	"encoding/base64"
+	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"reflect"
 )
 
 type field byte
@@ -15,9 +18,8 @@ const (
 	fieldLocation
 	fieldIdentifier
 	fieldSignature
-	fieldCaveatId
+	fieldCaveat
 	fieldVerificationId
-	fieldCaveatLocation
 )
 
 var fieldStrings = [...]string{
@@ -25,9 +27,8 @@ var fieldStrings = [...]string{
 	fieldLocation:       "location",
 	fieldIdentifier:     "identifier",
 	fieldSignature:      "signature",
-	fieldCaveatId:       "cid",
+	fieldCaveat:         "cav",
 	fieldVerificationId: "vid",
-	fieldCaveatLocation: "cl",
 }
 
 func (f field) String() string {
@@ -39,10 +40,10 @@ func (f field) String() string {
 
 // macaroonJSON defines the JSON format for macaroons.
 type macaroonJSON struct {
-	Caveats    []caveatJSON `json:"caveats"`
-	Location   string       `json:"location"`
-	Identifier string       `json:"identifier"`
-	Signature  string       `json:"signature"` // hex-encoded
+	Caveats    string `json:"caveats"`
+	Location   string `json:"location"`
+	Identifier string `json:"identifier"`
+	Signature  string `json:"signature"` // hex-encoded
 }
 
 // caveatJSON defines the JSON format for caveats within a macaroon.
@@ -58,14 +59,7 @@ func (m *Macaroon) MarshalJSON() ([]byte, error) {
 		Location:   m.Location(),
 		Identifier: m.dataStr(m.id),
 		Signature:  hex.EncodeToString(m.sig),
-		Caveats:    make([]caveatJSON, len(m.caveats)),
-	}
-	for i, cav := range m.caveats {
-		mjson.Caveats[i] = caveatJSON{
-			Location: m.dataStr(cav.location),
-			CID:      m.dataStr(cav.caveatId),
-			VID:      base64.StdEncoding.EncodeToString(m.dataBytes(cav.verificationId)),
-		}
+		Caveats:    hex.EncodeToString(m.caveatsRaw()),
 	}
 	data, err := json.Marshal(mjson)
 	if err != nil {
@@ -77,6 +71,7 @@ func (m *Macaroon) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements json.Unmarshaler.
 func (m *Macaroon) UnmarshalJSON(jsonData []byte) error {
 	var mjson macaroonJSON
+	var ok bool
 	err := json.Unmarshal(jsonData, &mjson)
 	if err != nil {
 		return fmt.Errorf("cannot unmarshal json data: %v", err)
@@ -88,16 +83,15 @@ func (m *Macaroon) UnmarshalJSON(jsonData []byte) error {
 	if err != nil {
 		return fmt.Errorf("cannot decode macaroon signature %q: %v", m.sig, err)
 	}
-	m.caveats = m.caveats[:0]
-	for _, cav := range mjson.Caveats {
-		vid, err := base64.StdEncoding.DecodeString(cav.VID)
-		if err != nil {
-			return fmt.Errorf("cannot decode verification id %q: %v", cav.VID, err)
-		}
-		if _, err := m.appendCaveat(cav.CID, vid, cav.Location); err != nil {
-			return err
-		}
+	cavData, err := hex.DecodeString(mjson.Caveats)
+	if err != nil {
+		return fmt.Errorf("cannot decode macaroon caveats %q: %v", m.caveats, err)
 	}
+	m.caveats, ok = m.appendPacket(fieldCaveat, cavData)
+	if !ok {
+		return fmt.Errorf("cannot decode macaroon caveats")
+	}
+
 	return nil
 }
 
@@ -135,42 +129,12 @@ func (m *Macaroon) unmarshalBinaryNoCopy(data []byte) error {
 	if err != nil {
 		return err
 	}
-	var cav caveat
-	for {
-		p, err := m.parsePacket(start)
-		if err != nil {
-			return err
-		}
-		start += p.len()
-		switch f := m.fieldNum(p); f {
-		case fieldSignature:
-			// At the end of the caveats we find the signature.
-			if cav.caveatId.len() != 0 {
-				m.caveats = append(m.caveats, cav)
-			}
-			// Remove the signature from data.
-			m.data = m.data[0:p.start]
-			m.sig = append([]byte(nil), m.dataBytes(p)...)
-			return nil
-		case fieldCaveatId:
-			if cav.caveatId.len() != 0 {
-				m.caveats = append(m.caveats, cav)
-			}
-			cav.caveatId = p
-		case fieldVerificationId:
-			if cav.verificationId.len() != 0 {
-				return fmt.Errorf("repeated field %v in caveat", fieldVerificationId)
-			}
-			cav.verificationId = p
-		case fieldCaveatLocation:
-			if cav.location.len() != 0 {
-				return fmt.Errorf("repeated field %v in caveat", fieldLocation)
-			}
-			cav.location = p
-		default:
-			return fmt.Errorf("unexpected field %x", f)
-		}
+	start, m.caveats, err = m.expectPacket(start, fieldCaveat)
+	if err != nil {
+		return err
 	}
+
+	return nil
 }
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaler.
@@ -242,4 +206,191 @@ func (s *Slice) UnmarshalBinary(data []byte) error {
 		data = data[m.marshalBinaryLen():]
 	}
 	return nil
+}
+
+// convert data struct into []byte
+func MarshalCaveats(v interface{}) ([]byte, error) {
+	obj := reflect.ValueOf(v)
+
+	var out bytes.Buffer
+
+	for i := 0; i < obj.NumField(); i += 1 {
+		val := obj.Field(i)
+
+		switch val.Kind() {
+		case reflect.Ptr:
+			if val.IsNil() {
+				// ignore
+			} else {
+				data, err := valToBytes(val.Elem())
+				if err != nil {
+					return []byte{}, err
+				}
+
+				out.Write([]byte{byte(uint8(i))})  // Field Num
+				out.Write([]byte{byte(len(data))}) // Field Size
+				out.Write(data)                    // Field data itself
+			}
+		default:
+			panic("non-pointer type, please check structure field types")
+		}
+
+	}
+
+	return out.Bytes(), nil
+}
+
+func UnMarshalCaveats(v interface{}, data []byte) error {
+	dataLen := len(data)
+
+	obj := reflect.ValueOf(v).Elem()
+	typeOfStruct := obj.Type()
+
+	cursor := 0
+	for cursor < dataLen {
+		fieldNum := uint8(data[cursor])
+		dataSize := uint8(data[cursor+1])
+
+		fieldData := data[cursor+2 : cursor+2+int(dataSize)]
+
+		t := typeOfStruct.Field(int(fieldNum)).Type
+
+		val := obj.Field(int(fieldNum))
+
+		value, err := bytesToVal(t, fieldData)
+
+		if err != nil {
+			return err
+		}
+
+		val.Set(value)
+
+		cursor += 2 + int(dataSize)
+	}
+	return nil
+}
+
+func valToBytes(val reflect.Value) ([]byte, error) {
+	switch val.Kind() {
+	case reflect.Int, reflect.Uint:
+		panic("please always specify exact size, like int8 or uint32")
+
+	case reflect.Slice:
+		return val.Bytes(), nil
+
+	case reflect.String:
+		return []byte(val.String()), nil
+
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		buf := new(bytes.Buffer)
+		var err error
+
+		// TODO: refactor somehow
+		switch val.Kind() {
+		case reflect.Int8:
+			err = binary.Write(buf, binary.LittleEndian, int8(val.Int()))
+		case reflect.Int16:
+			err = binary.Write(buf, binary.LittleEndian, int16(val.Int()))
+		case reflect.Int32:
+			err = binary.Write(buf, binary.LittleEndian, int32(val.Int()))
+		case reflect.Int64:
+			err = binary.Write(buf, binary.LittleEndian, val.Int())
+		case reflect.Uint8:
+			err = binary.Write(buf, binary.LittleEndian, uint8(val.Uint()))
+		case reflect.Uint16:
+			err = binary.Write(buf, binary.LittleEndian, uint16(val.Uint()))
+		case reflect.Uint32:
+			err = binary.Write(buf, binary.LittleEndian, uint32(val.Uint()))
+		case reflect.Uint64:
+			err = binary.Write(buf, binary.LittleEndian, val.Uint())
+		default:
+			panic("bug in the code")
+		}
+		return buf.Bytes(), err
+
+	case reflect.Bool:
+		value := val.Bool()
+		if value {
+			return []byte{1}, nil
+		} else {
+			return []byte{0}, nil
+		}
+	default:
+		panic("Unsupported type, please check structure field types")
+	}
+
+	var data []byte
+	data = make([]byte, 5, 5)
+
+	return data, nil
+}
+
+func bytesToVal(val reflect.Type, data []byte) (reflect.Value, error) {
+	var err error
+
+	switch val.Elem().Kind() {
+	case reflect.Int, reflect.Uint:
+		panic("please always specify exact size, like int8 or uint32")
+
+	case reflect.Slice:
+		return reflect.ValueOf(&data), nil
+
+	case reflect.String:
+		str := string(data)
+		return reflect.ValueOf(&str), nil
+
+	case reflect.Bool:
+		var value bool
+		if data[0] == 1 {
+			value = true
+		} else if data[0] == 0 {
+			value = false
+		} else {
+			err = errors.New("can not decode input data")
+		}
+		return reflect.ValueOf(&value), err
+
+	// TODO: refactor somehow
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		buf := bytes.NewReader(data)
+		switch val.Elem().Kind() {
+		case reflect.Int8:
+			var n int8
+			err = binary.Read(buf, binary.LittleEndian, &n)
+			return reflect.ValueOf(&n), err
+		case reflect.Int16:
+			var n int16
+			err = binary.Read(buf, binary.LittleEndian, &n)
+			return reflect.ValueOf(&n), err
+		case reflect.Int32:
+			var n int32
+			err = binary.Read(buf, binary.LittleEndian, &n)
+			return reflect.ValueOf(&n), err
+		case reflect.Int64:
+			var n int64
+			err = binary.Read(buf, binary.LittleEndian, &n)
+			return reflect.ValueOf(&n), err
+		case reflect.Uint8:
+			var n uint8
+			err = binary.Read(buf, binary.LittleEndian, &n)
+			return reflect.ValueOf(&n), err
+		case reflect.Uint16:
+			var n uint16
+			err = binary.Read(buf, binary.LittleEndian, &n)
+			return reflect.ValueOf(&n), err
+		case reflect.Uint32:
+			var n uint32
+			err = binary.Read(buf, binary.LittleEndian, &n)
+			return reflect.ValueOf(&n), err
+		case reflect.Uint64:
+			var n uint64
+			err = binary.Read(buf, binary.LittleEndian, &n)
+			return reflect.ValueOf(&n), err
+		default:
+			panic("bug in the code")
+		}
+
+	default:
+		return reflect.ValueOf(nil), errors.New("unknown field type")
+	}
 }


### PR DESCRIPTION
DO NOT MERGE
Another, much more efficient way of handling caveats.

Simple script for testing:
https://gist.github.com/thousandsofthem/b378e04cca1d9f7bf5f8

What's ok:
- serializing / unserializing structs in efficient manner, strings, []bytes, *ints, *uints, bools supported
- (un)marshaling to binary, json works with no issues

What's wrong:
- i'll add floats later if required
- `int`, `uint`s are not supported for safety - their size can vary from machine to machine
- tests are not up to date
- code is not cleaned up
- primary concern - verification failing for unknown reason. need help here :(

@edsrzf could  you take a look? something wrong with verification, don't know where i missed a screw
